### PR TITLE
Handle null JCR properties in media gallery renderers

### DIFF
--- a/src/main/java/org/jahia/modules/mediagalleries/initializers/GalleryTypeInitializer.java
+++ b/src/main/java/org/jahia/modules/mediagalleries/initializers/GalleryTypeInitializer.java
@@ -73,17 +73,28 @@ public class GalleryTypeInitializer extends AbstractChoiceListRenderer implement
      * {@inheritDoc}
      */
     public String getStringRendering(RenderContext context, JCRPropertyWrapper propertyWrapper) throws RepositoryException {
+        if (propertyWrapper == null) {
+            return "";
+        }
+
         final StringBuilder sb = new StringBuilder();
 
         if (propertyWrapper.isMultiple()) {
             sb.append('{');
             final Value[] values = propertyWrapper.getValues();
-            for (Value value : values) {
-                sb.append('[').append(value.getString()).append(']');
+            if (values != null) {
+                for (Value value : values) {
+                    if (value != null) {
+                        sb.append('[').append(value.getString()).append(']');
+                    }
+                }
             }
             sb.append('}');
         } else {
-            sb.append('[').append(propertyWrapper.getValue().getString()).append(']');
+            final Value value = propertyWrapper.getValue();
+            if (value != null) {
+                sb.append('[').append(value.getString()).append(']');
+            }
         }
 
         return sb.toString();
@@ -93,6 +104,9 @@ public class GalleryTypeInitializer extends AbstractChoiceListRenderer implement
      * {@inheritDoc}
      */
     public String getStringRendering(Locale locale, ExtendedPropertyDefinition propDef, Object propertyValue) throws RepositoryException {
+        if (propertyValue == null) {
+            return "[]";
+        }
         return "[" + propertyValue.toString() + "]";
     }
 }

--- a/src/main/java/org/jahia/modules/mediagalleries/initializers/LinkTypeInitializer.java
+++ b/src/main/java/org/jahia/modules/mediagalleries/initializers/LinkTypeInitializer.java
@@ -77,17 +77,28 @@ public class LinkTypeInitializer extends AbstractChoiceListRenderer implements M
      * {@inheritDoc}
      */
     public String getStringRendering(RenderContext context, JCRPropertyWrapper propertyWrapper) throws RepositoryException {
+        if (propertyWrapper == null) {
+            return "";
+        }
+
         final StringBuilder sb = new StringBuilder();
 
         if (propertyWrapper.isMultiple()) {
             sb.append('{');
             final Value[] values = propertyWrapper.getValues();
-            for (Value value : values) {
-                sb.append('[').append(value.getString()).append(']');
+            if (values != null) {
+                for (Value value : values) {
+                    if (value != null) {
+                        sb.append('[').append(value.getString()).append(']');
+                    }
+                }
             }
             sb.append('}');
         } else {
-            sb.append('[').append(propertyWrapper.getValue().getString()).append(']');
+            final Value value = propertyWrapper.getValue();
+            if (value != null) {
+                sb.append('[').append(value.getString()).append(']');
+            }
         }
 
         return sb.toString();
@@ -97,6 +108,9 @@ public class LinkTypeInitializer extends AbstractChoiceListRenderer implements M
      * {@inheritDoc}
      */
     public String getStringRendering(Locale locale, ExtendedPropertyDefinition propDef, Object propertyValue) throws RepositoryException {
+        if (propertyValue == null) {
+            return "[]";
+        }
         return "[" + propertyValue.toString() + "]";
     }
 }


### PR DESCRIPTION
## Summary
- guard the media gallery choice list renderers against null `JCRPropertyWrapper` and `Value` instances
- return empty placeholders when the rendered property value is null to avoid runtime exceptions

## Testing
- `mvn -q test` *(fails: requires org.jahia.modules:jahia-modules parent from remote repository, network unavailable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc1b8b7b90832cb8fee9c53e30722b